### PR TITLE
[STY] use isort instead of sort python import

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,11 +32,11 @@ repos:
   - id: pyupgrade
     args: [--py38-plus]
 
-- repo: https://github.com/asottile/reorder-python-imports
-  rev: v3.12.0
+- repo: https://github.com/pycqa/isort
+  rev: 5.13.2
   hooks:
-  - id: reorder-python-imports
-    args: [--py38-plus, --add-import, from __future__ import annotations]
+  - id: isort
+    args: [--profile, black, --settings-path, pyproject.toml]
 
 - repo: https://github.com/psf/black
   rev: 24.1.1

--- a/bids/ext/reports/__init__.py
+++ b/bids/ext/reports/__init__.py
@@ -2,12 +2,8 @@
 
 from __future__ import annotations
 
-from . import _version
-from . import parameters
-from . import parsing
-from . import report
-from .due import Doi
-from .due import due
+from . import _version, parameters, parsing, report
+from .due import Doi, due
 from .report import BIDSReport
 
 __all__ = ["BIDSReport", "parameters", "parsing", "report"]

--- a/bids/ext/reports/cli.py
+++ b/bids/ext/reports/cli.py
@@ -5,15 +5,15 @@ from __future__ import annotations
 import argparse
 import sys
 from pathlib import Path
-from typing import IO
-from typing import Sequence
+from typing import IO, Sequence
 
 import rich
+from bids.layout import BIDSLayout
+
+from bids.ext.reports import BIDSReport
 
 from ._version import __version__
 from .logger import pybids_reports_logger
-from bids.ext.reports import BIDSReport
-from bids.layout import BIDSLayout
 
 # from bids.reports import BIDSReport
 LOGGER = pybids_reports_logger()

--- a/bids/ext/reports/parameters.py
+++ b/bids/ext/reports/parameters.py
@@ -5,15 +5,12 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
+from bids.layout import BIDSFile, BIDSLayout
 from nibabel import Nifti1Image
 from num2words import num2words
 
 from .logger import pybids_reports_logger
-from .utils import list_to_str
-from .utils import num_to_str
-from .utils import remove_duplicates
-from bids.layout import BIDSFile
-from bids.layout import BIDSLayout
+from .utils import list_to_str, num_to_str, remove_duplicates
 
 """Functions for building strings for individual parameters."""
 LOGGER = pybids_reports_logger()

--- a/bids/ext/reports/parsing.py
+++ b/bids/ext/reports/parsing.py
@@ -6,14 +6,12 @@ from pathlib import Path
 from typing import Any
 
 import nibabel as nib
+from bids.layout import BIDSFile, BIDSLayout
 from nibabel.filebasedimages import ImageFileError
 
-from . import parameters
-from . import templates
+from . import parameters, templates
 from .logger import pybids_reports_logger
 from .utils import collect_associated_files
-from bids.layout import BIDSFile
-from bids.layout import BIDSLayout
 
 LOGGER = pybids_reports_logger()
 

--- a/bids/ext/reports/report.py
+++ b/bids/ext/reports/report.py
@@ -7,13 +7,11 @@ import os.path as op
 from collections import Counter
 from typing import Any
 
+from bids.layout import BIDSFile, BIDSLayout
 from rich import print
 
-from . import parsing
-from . import utils
+from . import parsing, utils
 from .logger import pybids_reports_logger
-from bids.layout import BIDSFile
-from bids.layout import BIDSLayout
 
 LOGGER = pybids_reports_logger()
 

--- a/bids/ext/reports/tests/conftest.py
+++ b/bids/ext/reports/tests/conftest.py
@@ -3,14 +3,13 @@
 from __future__ import annotations
 
 import json
-from os.path import abspath
-from os.path import join
+from os.path import abspath, join
 
 import nibabel as nib
 import pytest
+from bids.tests import get_test_data_path
 
 from bids import BIDSLayout
-from bids.tests import get_test_data_path
 
 
 @pytest.fixture

--- a/bids/ext/reports/tests/test_parsing.py
+++ b/bids/ext/reports/tests/test_parsing.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from bids.tests import get_test_data_path
+
 from bids import BIDSLayout
 from bids.ext.reports import parsing
-from bids.tests import get_test_data_path
 
 
 def test_anat_info_smoke(testlayout, testconfig):

--- a/bids/ext/reports/tests/test_report.py
+++ b/bids/ext/reports/tests/test_report.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 import json
 from collections import Counter
-from os.path import abspath
-from os.path import join
+from os.path import abspath, join
+
+from bids.tests import get_test_data_path
 
 from bids.ext.reports import BIDSReport
-from bids.tests import get_test_data_path
 
 
 def test_report_init(testlayout):

--- a/bids/ext/reports/tests/test_templates.py
+++ b/bids/ext/reports/tests/test_templates.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from bids.ext.reports import parsing
-from bids.ext.reports import templates
+from bids.ext.reports import parsing, templates
 
 
 def test_pet():

--- a/bids/ext/reports/utils.py
+++ b/bids/ext/reports/utils.py
@@ -8,9 +8,9 @@ from __future__ import annotations
 
 from typing import Any
 
+from bids.layout import BIDSFile, BIDSLayout
+
 from .logger import pybids_reports_logger
-from bids.layout import BIDSFile
-from bids.layout import BIDSLayout
 
 LOGGER = pybids_reports_logger()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,3 +130,10 @@ source = [
 
 [tool.coverage.report]
 include_namespace_packages = true
+
+
+[tool.isort]
+combine_as_imports = true
+line_length = 99
+profile = "black"
+skip_gitignore = true


### PR DESCRIPTION
- avoid "tug of war" with black when using pre-commit
